### PR TITLE
Add PropertyConstraint<T>

### DIFF
--- a/src/NUnitConstraints/IConstraintBuilder.cs
+++ b/src/NUnitConstraints/IConstraintBuilder.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework.Constraints;
+
+namespace InsightArchitectures.Testing
+{
+    /// <summary>
+    /// Helper interface to fluently compose constraints.
+    /// </summary>
+    public interface IConstraintBuilder
+    {
+        /// <summary>
+        /// Wraps the given <paramref name="constraint"/> into another <see cref="IConstraint"/>.
+        /// </summary>
+        /// <param name="constraint">The <see cref="IConstraint" /> to wrap.</param>
+        /// <returns>A wrapped constraint.</returns>
+        IConstraint That(IConstraint constraint);
+    }
+}

--- a/src/NUnitConstraints/Is.cs
+++ b/src/NUnitConstraints/Is.cs
@@ -1,0 +1,28 @@
+using System;
+using NUnit.Framework.Constraints;
+
+namespace InsightArchitectures.Testing
+{
+#pragma warning disable CA1716 // Identifiers should not match keywords
+#pragma warning disable CA1000 // Do not declare static members on generic types
+    /// <summary>
+    /// A set of helpers that can be used when authoring NUnit-based tests.
+    /// </summary>
+    /// <typeparam name="T">Specifies the type of the test subject.</typeparam>
+    public static class Is<T>
+    {
+        /// <summary>
+        /// Selects a property of the test subject and encapsulates it within a <see cref="IConstraintBuilder" />.
+        /// </summary>
+        /// <param name="selector">The property to be tested.</param>
+        /// <returns>An instance of <see cref="IConstraintBuilder" /> containing the reference to the selected property.</returns>
+        public static IConstraintBuilder With(Func<T, object> selector)
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+
+            return new PropertySelectorConstraintBuilder<T>(selector);
+        }
+    }
+#pragma warning restore CA1716 // Identifiers should not match keywords
+#pragma warning restore CA1000 // Do not declare static members on generic types
+}

--- a/src/NUnitConstraints/PropertyConstraint.cs
+++ b/src/NUnitConstraints/PropertyConstraint.cs
@@ -35,4 +35,30 @@ namespace InsightArchitectures.Testing
             throw new NotSupportedException();
         }
     }
+
+    /// <summary>
+    /// An implementation of <see cref="IConstraintBuilder"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the test subject used to select the property to test.</typeparam>
+    public class PropertySelectorConstraintBuilder<T> : IConstraintBuilder
+    {
+        private readonly Func<T, object> _valueSelector;
+
+        /// <summary>
+        /// Creates a <see cref="PropertySelectorConstraintBuilder{T}" /> targeting a specific property of <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="valueSelector"></param>
+        public PropertySelectorConstraintBuilder(Func<T, object> valueSelector)
+        {
+            _valueSelector = valueSelector ?? throw new ArgumentNullException(nameof(valueSelector));
+        }
+
+        /// <inheritdoc />
+        public IConstraint That(IConstraint constraint)
+        {
+            _ = constraint ?? throw new ArgumentNullException(nameof(constraint));
+
+            return new PropertyConstraint<T>(_valueSelector, constraint);
+        }
+    }
 }

--- a/src/NUnitConstraints/PropertyConstraint.cs
+++ b/src/NUnitConstraints/PropertyConstraint.cs
@@ -1,0 +1,38 @@
+using System;
+using NUnit.Framework.Constraints;
+
+namespace InsightArchitectures.Testing
+{
+    /// <summary>
+    /// A NUnit constraint that applies a constraint to a property of the tested object.
+    /// </summary>
+    /// <typeparam name="T">The type of the tested object.</typeparam>
+    public class PropertyConstraint<T> : Constraint
+    {
+        private readonly Func<T, object> _valueSelector;
+        private readonly IConstraint _constraint;
+
+        /// <summary>
+        /// Creates an instance of <see cref="PropertyConstraint{T}" />.
+        /// </summary>
+        /// <param name="valueSelector">The property whose value will have the <paramref name="constraint"/> applied to.</param>
+        /// <param name="constraint">The constraint to apply to the value of the property selected by <paramref name="valueSelector"/>.</param>
+        public PropertyConstraint(Func<T, object> valueSelector, IConstraint constraint)
+        {
+            _valueSelector = valueSelector ?? throw new ArgumentNullException(nameof(valueSelector));
+            _constraint = constraint ?? throw new ArgumentNullException(nameof(constraint));
+        }
+
+        /// <inheritdoc />
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            if (actual is T item)
+            {
+                var value = _valueSelector(item);
+                return _constraint.ApplyTo(value);
+            }
+
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <RootNamespace>Tests</RootNamespace>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Tests.MoqMatchers.NUnit/Tests.MoqMatchers.NUnit.csproj
+++ b/tests/Tests.MoqMatchers.NUnit/Tests.MoqMatchers.NUnit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Tests.NUnitConstraints/PropertyConstraintTests.cs
+++ b/tests/Tests.NUnitConstraints/PropertyConstraintTests.cs
@@ -2,6 +2,7 @@ using System;
 using AutoFixture.Idioms;
 using InsightArchitectures.Testing;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace Tests
 {
@@ -21,6 +22,12 @@ namespace Tests
         }
 
         [Test, CustomAutoData]
+        public void Fluent_syntax_succeeds(CompositeType test)
+        {
+            Assert.That(test, Is<CompositeType>.With(p => p.IntValue).That(Is.EqualTo(test.IntValue)));
+        }
+
+        [Test, CustomAutoData]
         public void ApplyTo_returns_success_when_expected(CompositeType test)
         {
             var sut = new PropertyConstraint<CompositeType>(ct => ct.StringValue, Is.EqualTo(test.StringValue));
@@ -36,6 +43,25 @@ namespace Tests
             var sut = new PropertyConstraint<CompositeType>(ct => ct.StringValue, Is.EqualTo("Hello world"));
 
             Assert.That(() => sut.ApplyTo(test), Throws.Exception.TypeOf<NotSupportedException>());
+        }
+    }
+
+    [TestFixture]
+    [TestOf(typeof(PropertySelectorConstraintBuilder<>))]
+    public class PropertySelectorConstraintBuilderTests
+    {
+        [Test, CustomAutoData]
+        public void Constructor_does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(PropertySelectorConstraintBuilder<>).GetConstructors());
+
+        [Test, CustomAutoData]
+        public void That_does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(PropertySelectorConstraintBuilder<>).GetMethod("That"));
+
+        [Test, CustomAutoData]
+        public void That_returns_PropertyConstraint_T(PropertySelectorConstraintBuilder<CompositeType> sut, IConstraint innerConstraint)
+        {
+            var result = sut.That(innerConstraint);
+
+            Assert.That(result, Is.Not.Null.And.InstanceOf<IConstraint>());
         }
     }
 }

--- a/tests/Tests.NUnitConstraints/PropertyConstraintTests.cs
+++ b/tests/Tests.NUnitConstraints/PropertyConstraintTests.cs
@@ -1,0 +1,41 @@
+using System;
+using AutoFixture.Idioms;
+using InsightArchitectures.Testing;
+using NUnit.Framework;
+
+namespace Tests
+{
+    [TestFixture]
+    [TestOf(typeof(PropertyConstraint<>))]
+    public class PropertyConstraintTests
+    {
+        [Test, CustomAutoData]
+        public void Constructor_does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(PropertyConstraint<>).GetConstructors());
+
+        [Test, CustomAutoData]
+        public void Assert_succeeds(CompositeType test)
+        {
+            var sut = new PropertyConstraint<CompositeType>(ct => ct.StringValue, Is.EqualTo(test.StringValue));
+
+            Assert.That(test, sut);
+        }
+
+        [Test, CustomAutoData]
+        public void ApplyTo_returns_success_when_expected(CompositeType test)
+        {
+            var sut = new PropertyConstraint<CompositeType>(ct => ct.StringValue, Is.EqualTo(test.StringValue));
+
+            var result = sut.ApplyTo(test);
+
+            Assert.That(result.IsSuccess, Is.True);
+        }
+
+        [Test, CustomAutoData]
+        public void ApplyTo_throws_not_supported_if_test_is_not_same_as_type(object test)
+        {
+            var sut = new PropertyConstraint<CompositeType>(ct => ct.StringValue, Is.EqualTo("Hello world"));
+
+            Assert.That(() => sut.ApplyTo(test), Throws.Exception.TypeOf<NotSupportedException>());
+        }
+    }
+}

--- a/tests/Tests.NUnitConstraints/TestTypes.cs
+++ b/tests/Tests.NUnitConstraints/TestTypes.cs
@@ -1,0 +1,9 @@
+﻿namespace Tests
+{
+    public class CompositeType
+    {
+        public int IntValue { get; set; }
+
+        public string StringValue { get; set; }
+    }
+}

--- a/tests/Tests.NUnitConstraints/Tests.NUnitConstraints.csproj
+++ b/tests/Tests.NUnitConstraints/Tests.NUnitConstraints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This constraint gives the possibility to traverse the object graph in a typed fashion.

```csharp
var actual = new CompositeType { IntValue = 42 };
Assert.That(actual, new PropertyCostraint<CompositeType>(ct => ct.IntValue, Is.EqualTo(42)));
```

The same assertion can be written as:
```csharp
Assert.That(test, Is<CompositeType>.With(p => p.IntValue).That(Is.EqualTo(42)));
```